### PR TITLE
feat: implement OTP-based account verification

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,7 +1,7 @@
 import os
 import random
 import uuid
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import Optional
 
 import jwt
@@ -114,8 +114,50 @@ def sign_up_user(user_data: UserCreate):
 
 @app.post("/verify", tags=["Authentication"])
 def verify_user_account(otp_data: OTPVerifyRequest):
-    # TODO: Implement OTP verification logic
-    return {"message": "Verification endpoint not yet implemented"}
+    """ Verify user account using OTP"""
+
+    # Check the OTP record
+    otp_rec = otp_record.find_one({
+        "email": otp_data.email,
+        "otp": otp_data.otp
+    })
+
+    if not otp_rec:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Incorrect OTP",
+        ) 
+    
+    # Check for 10 minutes otp expiry 
+    otp_age = datetime.now(timezone.utc) - otp_record["created_at"]
+    OTP_EXPIRY_MINUTES = 10
+    
+    if otp_age > timedelta(minutes=OTP_EXPIRY_MINUTES):
+        # Delete expired OTP
+        otp_record.delete_one({"email": otp_record["email"]})
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="OTP has expired. Please request a new one"
+        )
+    
+    # Find user
+    user = user_auth.find_one({"email": otp_record["email"]})
+
+    if not user:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="User not found"
+        )
+    
+    user_auth.update_one({"email": user["email"]}, {
+        "$set": {
+            "is_verified": True,
+            "updated_at": datetime.now(timezone.utc)
+        }
+    })
+
+    otp_record.delete_one({"email": otp_rec["email"]})
+    return {"message": "Account verified successfully"}
 
 
 @app.post("/resend_otp", tags=["Authentication"])

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,6 @@
+import sys
+from pathlib import Path
+
+# Add project root to Python path
+project_root = Path(__file__).parent.parent
+sys.path.insert(0, str(project_root))

--- a/tests/otp_verification_test.py
+++ b/tests/otp_verification_test.py
@@ -1,0 +1,113 @@
+import pytest
+from fastapi.testclient import TestClient
+from datetime import datetime, timedelta, timezone
+from bson import ObjectId
+from config.database import user_auth, otp_record
+from main import app
+
+client = TestClient(app)
+
+@pytest.fixture
+def sample_user():
+    """Create a test unverified user"""
+    user_id = ObjectId()
+    test_user = {
+    "_id": ObjectId(),  
+    "email": "testuser@example.com",
+    "name": "Test User",
+    "password": "TestPassword123",
+    "created_at": datetime.now(timezone.utc)
+    }
+
+    user_auth.insert_one(test_user)
+    yield test_user
+    # Cleanup
+    user_auth.delete_one({"_id": user_id})
+
+
+@pytest.fixture
+def valid_otp(sample_user):
+    """Create a valid OTP for the test user"""
+
+    otp = {
+        "_id": ObjectId(),
+        "email": sample_user["email"],
+        "otp": "123456",
+        "created_at": datetime.now(timezone.utc)
+    }
+    otp_record.insert_one(otp)
+    yield otp
+    # Cleanup
+    otp_record.delete_many({"email": sample_user["email"]})
+
+
+def test_verify_with_valid_otp(sample_user, valid_otp):
+    """Test successful OTP verification"""
+    response = client.post("/verify", json={
+        "email": sample_user["email"],
+        "otp": valid_otp["otp"]
+    })
+    
+    assert response.status_code == 200
+    assert response.json()["message"] == "Account verified successfully"
+    
+    # Verify user is marked as verified in DB
+    user = user_auth.find_one({"email": sample_user["email"]})
+    assert user["is_verified"] is True
+
+
+def test_verify_with_incorrect_otp(sample_user):
+    """Test verification with wrong OTP"""
+
+    response = client.post("/verify", json={
+        "email": sample_user["email"],
+        "otp": "999999"
+    })
+    
+    assert response.status_code == 400
+    assert "Incorrect OTP" in response.json()["detail"]
+
+
+def test_verify_with_expired_otp(sample_user):
+    """Test verification with expired OTP"""
+
+    expired_otp = {
+        "email": sample_user["email"],
+        "otp": "123456",
+        "created_at": datetime.now(timezone.utc) - timedelta(minutes=15)
+    }
+    otp_record.insert_one(expired_otp)
+    
+    response = client.post("/verify", json={
+        "email": sample_user["email"],
+        "otp": "123456"
+    })
+    
+    assert response.status_code == 400
+    assert "expired" in response.json()["detail"].lower()
+    
+    # Cleanup
+    otp_record.delete_many({"email": sample_user["email"]})
+
+
+def test_verify_nonexistent_user():
+    """Test verification for user that doesn't exist"""
+    response = client.post("/verify", json={
+        "email": "nonexistent@example.com",
+        "otp": "123456"
+    })
+    
+    assert response.status_code == 404
+    assert "User not found" in response.json()["detail"]
+
+
+def test_otp_is_deleted_after_use(sample_user, valid_otp):
+    """Test that OTP is deleted after successful verification"""
+    client.post("/verify", json={
+        "email": sample_user["email"],
+        "otp": valid_otp["otp"]
+    })
+    
+    # Check OTP is deleted
+    otp = otp_record.find_one({"email": sample_user["email"]})
+    assert otp is None


### PR DESCRIPTION
Hey team,

This PR closes #3 by implementing the OTP-based account verification feature and:
- Adding logic to verify user accounts with a generated OTP.
- Ensuring OTPs expire after a set duration of 10 minutes.
- Returning clear success and error responses to the frontend.
- Updating the user’s account status (is_verified) in the database after successful verification.
- Writing tests to confirm correctness and security of the implementation.

Let me know if any changes are needed. Thanks