### PR TITLE
 Implement Password Reset and OTP-Based Authentication Updates

### DIFF
--- a/main.py
+++ b/main.py
@@ -159,6 +159,12 @@ async def read_users_me(current_user: dict = Depends(get_current_user)):
 
 
 @app.post("/reset_password", tags=["Authentication"])
-def reset_password(user: ResetPasswordRequest):
-    # TODO: Implement password reset logic
-    return {"message": "Password reset endpoint not yet implemented"}
+def reset_password(payload: ResetPasswordRequest):
+    """Verify OTP and reset password"""
+    return reset_user_password(payload.email, payload.otp, payload.new_password)
+
+@app.post("/forgot_password", tags=["Authentication"])
+def forgot_password_request(request: ForgotPasswordRequest):
+    """Request password reset OTP"""
+    return request_password_reset(request.email)
+

--- a/schemas/schema.py
+++ b/schemas/schema.py
@@ -40,5 +40,6 @@ class LoginRequest(BaseModel):
 
 class ResetPasswordRequest(BaseModel):
     email: EmailStr
+    otp: str
     new_password: str = Field(min_length=6, max_length=20)
 


### PR DESCRIPTION
#6

This PR implements the password reset functionality and updates the authentication flow using the existing OTP system. Key changes include:

1. Schema Updates:
   - Updated ResetPasswordRequest to include the otp field for verifying password reset requests.

2. Service Layer:
   - Added request_password_reset to send OTP for password reset with rate-limiting.
   - Added reset_user_password to verify OTP and update user password securely.
   - Reused the existing OTP system for uniformity across authentication processes.

3. API Endpoints:
   - /forgot_password: Request password reset OTP.
   - /reset_password: Verify OTP and reset the password.
