### PR TITLE
[BUG] Login endpoint fails with KeyError: password_hash

### DIFF
--- a/auth/service.py
+++ b/auth/service.py
@@ -37,6 +37,11 @@ def get_user_via_username(username: str):
     user = user_auth.find_one({"username": username})
     return user_serializer(user)
 
+def _get_user_for_auth_by_email(email: str):
+    return user_auth.find_one({"email": email})
+
+def _get_user_for_auth_by_username(username: str):
+    return user_auth.find_one({"username": username})
 
 def user_exists_email(email: str) -> bool:
     """

--- a/main.py
+++ b/main.py
@@ -24,6 +24,8 @@ from auth.service import (
     generate_otp,
     get_user_via_email,
     get_user_via_username,
+    _get_user_for_auth_by_username,
+    _get_user_for_auth_by_email,
     user_exists_email,
     user_exists_username,
     user_serializer,
@@ -249,9 +251,9 @@ def login_user(form_data: OAuth2PasswordRequestForm = Depends()):
     FastAPI's form dependency expects 'username' and 'password' fields.
     """
     # Check if user exists (can be username or email)
-    user = get_user_via_username(form_data.username)
+    user = _get_user_for_auth_by_username(form_data.username)
     if not user:
-        user = get_user_via_email(form_data.username)
+        user = _get_user_for_auth_by_email(form_data.username)
 
     if not user or not verify_password(form_data.password, user["password_hash"]):
         raise HTTPException(


### PR DESCRIPTION
The /login endpoint is currently unusable because it relies on user-retrieval functions (get_user_via_username and get_user_via_email) that pass the user document through a serializer (user_serializer). This serializer intentionally removes the password_hash for security, causing the login logic to crash with a KeyError when it tries to verify the password.

Thus, before even having the testuser in the db then, I was getting this using curl to test the login endpoint:

<img width="1270" height="896" alt="Screenshot 2025-10-17 000819" src="https://github.com/user-attachments/assets/2356f516-8b99-4581-8d42-d170fbcbaa34" />

<img width="1234" height="860" alt="Screenshot 2025-10-17 000920" src="https://github.com/user-attachments/assets/26e4016c-7f16-4535-9de3-89c43499bb9e" />

After using the two new functions in auth/service.py to only fetch the complete user document and do not call the serializer, I am getting this:

<img width="1270" height="460" alt="Screenshot 2025-10-17 001827" src="https://github.com/user-attachments/assets/ff582f7a-fc45-4166-a10c-852c2e522f77" />

