### PR TITLE
feat: Augment recipe generation to handle additional input fields

### DIFF
--- a/main.py
+++ b/main.py
@@ -396,7 +396,12 @@ async def recipe_generation(recipe_data: RecipePayload, current_user:dict = Depe
         )
      # Main Implementation (with function calls)
     try:
-        generated_recipe = get_recipe_for_dish(recipe_data.food_name.strip())
+        generated_recipe = get_recipe_for_dish(
+            food_name=recipe_data.food_name.strip(),
+            servings=recipe_data.servings,
+            dietary_restriction=recipe_data.dietary_restriction,
+            extra_inputs=recipe_data.extra_inputs
+        )
     except Exception as exc:
         raise HTTPException(status_code=500, detail=f"Recipe generation failed: {exc}")
     if not generated_recipe:
@@ -416,7 +421,7 @@ async def recipe_generation(recipe_data: RecipePayload, current_user:dict = Depe
 
     return {
         "message": "Recipe request stored successfully.",
-        "food_name: recipe_data.food_name.strip(),"
+        "food_name": recipe_data.food_name.strip(),
         "generated_recipe": generated_recipe,
         "request_metadata": {
             "timestamp": request_document["timestamp"].isoformat() if "timestamp" in request_document else None,

--- a/src/recipe_generation/recipe_generation.py
+++ b/src/recipe_generation/recipe_generation.py
@@ -1,20 +1,44 @@
 # src/recipe-generation/recipe_generation.py
 
 import json
+from typing import Optional, List
 from .recipe_tools import generate_recipe
 
-def get_recipe_for_dish(food_name: str):
+def get_recipe_for_dish(
+    food_name: str,
+    servings: Optional[float] = None,
+    dietary_restriction: Optional[List[str]] = None,
+    extra_inputs: Optional[str] = None
+):
     """
-    A simple function to demonstrate how to use the recipe generation tool.
+    Generate a recipe for a dish with optional parameters.
     
     Args:
         food_name (str): The name of the dish to get a recipe for.
+        servings (Optional[float]): Number of servings/portions (e.g., 3, 4).
+        dietary_restriction (Optional[List[str]]): List of dietary restrictions 
+            (e.g., ["Vegetarian", "Vegan", "Lactose intolerant", "Gluten-free", 
+             "Nut allergy", "Diabetic", "Halal"]).
+        extra_inputs (Optional[str]): Additional context or preferences 
+            (e.g., "Preferred Cuisine: Yoruba").
         
     Returns:
         dict or None: The recipe data if successful, otherwise None.
     """
     print(f"Requesting recipe for: {food_name}")
-    recipe_data = generate_recipe(food_name)
+    if servings:
+        print(f"  - Servings: {servings}")
+    if dietary_restriction:
+        print(f"  - Dietary Restrictions: {', '.join(dietary_restriction)}")
+    if extra_inputs:
+        print(f"  - Extra Inputs: {extra_inputs}")
+    
+    recipe_data = generate_recipe(
+        food_name=food_name,
+        servings=servings,
+        dietary_restriction=dietary_restriction,
+        extra_inputs=extra_inputs
+    )
     
     if recipe_data:
         print("\n--- Successfully Generated Recipe ---")

--- a/src/recipe_generation/recipe_prompt.yml
+++ b/src/recipe_generation/recipe_prompt.yml
@@ -3,18 +3,21 @@ recipe_generation_prompt: |
 
   You MUST base your response primarily on the information from the **"Provided Recipe Data Context"** below. However, you can use your expertise to infer plausible values for fields like 'region' or 'spice_level' if they are not available in the context.
 
+  **User Preferences and Constraints:**
+  {user_preferences}
+
   **Provided Recipe Data Context:**
   ---
   {context_data}
   ---
 
-  Based on the context above, create a single, valid JSON object with the following structure. Do not include any text, greetings, or explanations before or after the JSON object.
+  Based on the context above and respecting the user preferences, create a single, valid JSON object with the following structure. Do not include any text, greetings, or explanations before or after the JSON object.
   {{
     "food_name": "Name of the dish",
     "description": "A brief, savory description of the dish. You can generate this based on the title and ingredients.",
     "region": "The Nigerian region or tribe the dish is most associated with (e.g., Yoruba).",
     "spice_level": "Mild, Medium, or Spicy (infer from ingredients like 'pepper').",
-    "servings": "e.g., 4",
+    "servings": "Number of servings based on user preference or default",
     "prep_time_minutes": "e.g., 15",
     "cook_time_minutes": "e.g., 45",
     "total_time_minutes": "e.g., 60",

--- a/src/recipe_generation/recipe_tools.py
+++ b/src/recipe_generation/recipe_tools.py
@@ -4,6 +4,7 @@ import yaml
 import requests
 import pandas as pd
 from pathlib import Path
+from typing import Optional
 from dotenv import load_dotenv
 from openai import AzureOpenAI
 from tavily import TavilyClient
@@ -185,13 +186,30 @@ def generate_step_image(step_description: str, food_name: str) -> str | None:
 # ========================================
 # Main Recipe Generation Function
 # ========================================
-def generate_recipe(food_name: str):
+def generate_recipe(
+    food_name: str,
+    servings: Optional[float] = None,
+    dietary_restriction: Optional[list] = None,
+    extra_inputs: Optional[str] = None
+):
     """
     Generates a recipe using combined sources:
     - Local Nigerian dataset (TF-IDF search)
     - TheMealDB API
     - Tavily web search
     Combines all info into a structured recipe using Azure OpenAI GPT-4o.
+    
+    Args:
+        food_name (str): The name of the dish to generate a recipe for.
+        servings (Optional[float]): Desired number of servings/portions.
+        dietary_restriction (Optional[list]): List of dietary restrictions to consider
+            (e.g., ["Vegetarian", "Vegan", "Lactose intolerant", "Gluten-free", 
+             "Nut allergy", "Diabetic", "Halal"]).
+        extra_inputs (Optional[str]): Additional user preferences or context 
+            (e.g., "Preferred Cuisine: Yoruba").
+    
+    Returns:
+        dict: The generated recipe JSON with all structured data.
     """
     print(f"\n🔍 Searching for recipe: {food_name}")
 
@@ -213,6 +231,20 @@ def generate_recipe(food_name: str):
         "mealdb_recipe": mealdb_recipe,
         "tavily_snippets": tavily_results,
     }
+    
+    # Build user preferences string for the prompt
+    user_preferences_parts = []
+    if servings:
+        user_preferences_parts.append(f"- Desired servings: {servings} portions/plates")
+    if dietary_restriction:
+        user_preferences_parts.append(f"- Dietary restrictions: {', '.join(dietary_restriction)}")
+    if extra_inputs:
+        user_preferences_parts.append(f"- Additional preferences: {extra_inputs}")
+    
+    if not user_preferences_parts:
+        user_preferences_str = "No specific user preferences provided."
+    else:
+        user_preferences_str = "\n".join(user_preferences_parts)
 
     # Step 4: Generate Structured Recipe via GPT
     
@@ -221,10 +253,9 @@ def generate_recipe(food_name: str):
     user_prompt_template = prompts.get("recipe_generation_prompt", "")
     user_prompt = user_prompt_template.format(
         food_name=food_name,
+        user_preferences=user_preferences_str,
         context_data=json.dumps(combined_context, indent=2)
     )
-
-    #user_prompt = f"Food name: {food_name}\n\nGrounded data:\n{json.dumps(combined_context, indent=2)}"
 
     try:
         response = client.chat.completions.create(
@@ -239,6 +270,14 @@ def generate_recipe(food_name: str):
 
         recipe_json = json.loads(response.choices[0].message.content)
         recipe_json["source"] = "combined (local + TheMealDB + Tavily)"
+        
+        # Add user preferences metadata to the recipe
+        if servings:
+            recipe_json["servings"] = servings
+        if dietary_restriction:
+            recipe_json["dietary_restrictions"] = dietary_restriction
+        if extra_inputs:
+            recipe_json["user_preferences"] = extra_inputs
         
         # === NEW LOGIC: Generate Images for Each Recipe Step ===
         if "steps" in recipe_json and isinstance(recipe_json["steps"], list):

--- a/tests/test_recipe_generation_enhanced.py
+++ b/tests/test_recipe_generation_enhanced.py
@@ -1,0 +1,321 @@
+"""
+Test suite for enhanced recipe generation with additional input fields.
+
+Tests verify that the recipe generation feature correctly handles:
+- servings (Optional[float])
+- dietary_restriction (Optional[List[str]])
+- extra_inputs (Optional[str])
+"""
+
+from datetime import timezone
+from types import SimpleNamespace
+from unittest.mock import patch, MagicMock
+
+import pytest
+from bson import ObjectId
+from fastapi.testclient import TestClient
+
+import main
+
+
+def mock_get_current_user():
+    """Mock implementation of get_current_user for testing."""
+    return {"username": "testuser", "email": "test@example.com"}
+
+
+# Override the dependency
+app = main.app
+app.dependency_overrides[main.get_current_user] = mock_get_current_user
+
+client = TestClient(app)
+
+
+class DummyRecipeCollection:
+    """In-memory stand-in for the recipe_requests collection."""
+
+    def __init__(self):
+        self.inserted_documents = []
+        self.inserted_ids = []
+
+    def insert_one(self, document):
+        stored_document = document.copy()
+        inserted_id = ObjectId()
+        self.inserted_documents.append(stored_document)
+        self.inserted_ids.append(inserted_id)
+        return SimpleNamespace(inserted_id=inserted_id)
+
+
+@pytest.fixture
+def mock_recipe_collection(monkeypatch):
+    dummy_collection = DummyRecipeCollection()
+    monkeypatch.setattr(main, "recipe_requests", dummy_collection)
+    return dummy_collection
+
+
+class TestRecipeGenerationWithServings:
+    """Test recipe generation with servings parameter."""
+    
+    def test_recipe_generation_with_servings(self, mock_recipe_collection):
+        """Test that servings parameter is properly passed through the generation flow."""
+        payload = {
+            "email": "test.user@example.com",
+            "food_name": "Jollof Rice",
+            "servings": 6,
+            "dietary_restriction": None,
+            "extra_inputs": None,
+        }
+
+        with patch('main.get_recipe_for_dish') as mock_recipe:
+            mock_recipe.return_value = {
+                "food_name": "Jollof Rice",
+                "servings": 6,
+                "description": "A delicious one-pot rice dish",
+            }
+            
+            response = client.post("/features/recipe_generation", json=payload)
+
+            # Verify the endpoint was called with the correct parameters
+            assert response.status_code == 200
+            mock_recipe.assert_called_once()
+            call_args = mock_recipe.call_args
+            
+            assert call_args.kwargs.get('food_name') == "Jollof Rice"
+            assert call_args.kwargs.get('servings') == 6
+            assert call_args.kwargs.get('dietary_restriction') is None
+            assert call_args.kwargs.get('extra_inputs') is None
+
+
+class TestRecipeGenerationWithDietaryRestrictions:
+    """Test recipe generation with dietary restrictions parameter."""
+    
+    def test_recipe_generation_with_single_dietary_restriction(self, mock_recipe_collection):
+        """Test with a single dietary restriction."""
+        payload = {
+            "email": "test.user@example.com",
+            "food_name": "Egusi Soup",
+            "servings": None,
+            "dietary_restriction": ["Vegetarian"],
+            "extra_inputs": None,
+        }
+
+        with patch('main.get_recipe_for_dish') as mock_recipe:
+            mock_recipe.return_value = {
+                "food_name": "Egusi Soup",
+                "dietary_restrictions": ["Vegetarian"],
+                "description": "A vegetarian version of egusi soup",
+            }
+            
+            response = client.post("/features/recipe_generation", json=payload)
+
+            assert response.status_code == 200
+            mock_recipe.assert_called_once()
+            call_args = mock_recipe.call_args
+            
+            assert call_args.kwargs.get('dietary_restriction') == ["Vegetarian"]
+    
+    def test_recipe_generation_with_multiple_dietary_restrictions(self, mock_recipe_collection):
+        """Test with multiple dietary restrictions."""
+        payload = {
+            "email": "test.user@example.com",
+            "food_name": "Pounded Yam",
+            "servings": 4,
+            "dietary_restriction": ["Vegetarian", "Gluten-free", "Nut allergy"],
+            "extra_inputs": None,
+        }
+
+        with patch('main.get_recipe_for_dish') as mock_recipe:
+            mock_recipe.return_value = {
+                "food_name": "Pounded Yam",
+                "servings": 4,
+                "dietary_restrictions": ["Vegetarian", "Gluten-free", "Nut allergy"],
+            }
+            
+            response = client.post("/features/recipe_generation", json=payload)
+
+            assert response.status_code == 200
+            mock_recipe.assert_called_once()
+            call_args = mock_recipe.call_args
+            
+            assert call_args.kwargs.get('dietary_restriction') == ["Vegetarian", "Gluten-free", "Nut allergy"]
+
+
+class TestRecipeGenerationWithExtraInputs:
+    """Test recipe generation with extra_inputs parameter."""
+    
+    def test_recipe_generation_with_cuisine_preference(self, mock_recipe_collection):
+        """Test with cuisine preference in extra_inputs."""
+        payload = {
+            "email": "test.user@example.com",
+            "food_name": "Moi Moi",
+            "servings": None,
+            "dietary_restriction": None,
+            "extra_inputs": "Preferred Cuisine: Yoruba, Traditional method",
+        }
+
+        with patch('main.get_recipe_for_dish') as mock_recipe:
+            mock_recipe.return_value = {
+                "food_name": "Moi Moi",
+                "description": "Traditional Yoruba steamed bean pudding",
+                "user_preferences": "Preferred Cuisine: Yoruba, Traditional method",
+            }
+            
+            response = client.post("/features/recipe_generation", json=payload)
+
+            assert response.status_code == 200
+            mock_recipe.assert_called_once()
+            call_args = mock_recipe.call_args
+            
+            assert call_args.kwargs.get('extra_inputs') == "Preferred Cuisine: Yoruba, Traditional method"
+
+
+class TestRecipeGenerationWithAllParameters:
+    """Test recipe generation with all parameters provided."""
+    
+    def test_recipe_generation_with_all_fields(self, mock_recipe_collection):
+        """Test that all input fields are properly integrated into recipe generation."""
+        payload = {
+            "email": "chef@example.com",
+            "food_name": "Pepper Rice",
+            "servings": 8,
+            "dietary_restriction": ["Halal", "Gluten-free"],
+            "extra_inputs": "Preferred Cuisine: Hausa, Spicy level: Medium",
+        }
+
+        with patch('main.get_recipe_for_dish') as mock_recipe:
+            mock_recipe.return_value = {
+                "food_name": "Pepper Rice",
+                "servings": 8,
+                "spice_level": "Medium",
+                "dietary_restrictions": ["Halal", "Gluten-free"],
+                "user_preferences": "Preferred Cuisine: Hausa, Spicy level: Medium",
+                "region": "Hausa",
+                "ingredients": [
+                    {"name": "Rice", "quantity": "4 cups", "notes": "parboiled"},
+                    {"name": "Red peppers", "quantity": "4 large", "notes": "blended"},
+                ],
+                "steps": [
+                    {"step_number": 1, "instruction": "Fry the peppers"},
+                    {"step_number": 2, "instruction": "Add rice and cook"},
+                ],
+            }
+            
+            response = client.post("/features/recipe_generation", json=payload)
+
+            assert response.status_code == 200
+            body = response.json()
+            
+            # Verify all parameters were passed to the generation function
+            mock_recipe.assert_called_once()
+            call_args = mock_recipe.call_args
+            
+            assert call_args.kwargs.get('food_name') == "Pepper Rice"
+            assert call_args.kwargs.get('servings') == 8
+            assert call_args.kwargs.get('dietary_restriction') == ["Halal", "Gluten-free"]
+            assert call_args.kwargs.get('extra_inputs') == "Preferred Cuisine: Hausa, Spicy level: Medium"
+            
+            # Verify the generated recipe includes user preferences
+            generated_recipe = body["generated_recipe"]
+            assert generated_recipe["servings"] == 8
+            assert "Halal" in generated_recipe["dietary_restrictions"]
+            assert "Gluten-free" in generated_recipe["dietary_restrictions"]
+            assert "Hausa" in generated_recipe["user_preferences"]
+
+
+class TestRecipeGenerationEdgeCases:
+    """Test edge cases and error handling."""
+    
+    def test_recipe_generation_with_zero_servings(self, mock_recipe_collection):
+        """Test that zero servings is handled correctly."""
+        payload = {
+            "email": "test@example.com",
+            "food_name": "Okra Soup",
+            "servings": 0,
+            "dietary_restriction": None,
+            "extra_inputs": None,
+        }
+
+        with patch('main.get_recipe_for_dish') as mock_recipe:
+            mock_recipe.return_value = {"food_name": "Okra Soup"}
+            
+            response = client.post("/features/recipe_generation", json=payload)
+
+            assert response.status_code == 200
+            call_args = mock_recipe.call_args
+            assert call_args.kwargs.get('servings') == 0
+    
+    def test_recipe_generation_with_fractional_servings(self, mock_recipe_collection):
+        """Test that fractional servings are handled correctly."""
+        payload = {
+            "email": "test@example.com",
+            "food_name": "Garri and Soup",
+            "servings": 2.5,
+            "dietary_restriction": None,
+            "extra_inputs": None,
+        }
+
+        with patch('main.get_recipe_for_dish') as mock_recipe:
+            mock_recipe.return_value = {"food_name": "Garri and Soup", "servings": 2.5}
+            
+            response = client.post("/features/recipe_generation", json=payload)
+
+            assert response.status_code == 200
+            call_args = mock_recipe.call_args
+            assert call_args.kwargs.get('servings') == 2.5
+    
+    def test_recipe_generation_with_empty_dietary_list(self, mock_recipe_collection):
+        """Test with an empty dietary restriction list."""
+        payload = {
+            "email": "test@example.com",
+            "food_name": "Fufu",
+            "servings": None,
+            "dietary_restriction": [],
+            "extra_inputs": None,
+        }
+
+        with patch('main.get_recipe_for_dish') as mock_recipe:
+            mock_recipe.return_value = {"food_name": "Fufu"}
+            
+            response = client.post("/features/recipe_generation", json=payload)
+
+            assert response.status_code == 200
+            call_args = mock_recipe.call_args
+            assert call_args.kwargs.get('dietary_restriction') == []
+
+
+class TestRecipeGenerationPersistence:
+    """Test that recipe requests are properly persisted with all fields."""
+    
+    def test_recipe_request_persisted_with_all_fields(self, mock_recipe_collection):
+        """Test that all recipe request fields are stored in the database."""
+        payload = {
+            "email": "persistent.user@example.com",
+            "food_name": "Suya",
+            "servings": 2,
+            "dietary_restriction": ["Vegan", "Diabetic"],
+            "extra_inputs": "Less spicy, no nuts",
+        }
+
+        with patch('main.get_recipe_for_dish') as mock_recipe:
+            mock_recipe.return_value = {
+                "food_name": "Suya",
+                "servings": 2,
+                "dietary_restrictions": ["Vegan", "Diabetic"],
+            }
+            
+            response = client.post("/features/recipe_generation", json=payload)
+
+            assert response.status_code == 200
+            
+            # Verify the document was inserted with all fields
+            assert len(mock_recipe_collection.inserted_documents) == 1
+            inserted_doc = mock_recipe_collection.inserted_documents[0]
+            
+            assert inserted_doc["email"] == "persistent.user@example.com"
+            assert inserted_doc["food_name"] == "Suya"
+            assert inserted_doc["servings"] == 2
+            assert inserted_doc["dietary_restriction"] == ["Vegan", "Diabetic"]
+            assert inserted_doc["extra_inputs"] == "Less spicy, no nuts"
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Augment Recipe Generation to Handle Additional Input Fields 

This PR enhances the recipe generation feature to support all fields in the `RecipePayload` schema, including:
- `servings` (number of portions)
- `dietary_restriction` (list of dietary restrictions)
- `extra_inputs` (custom user preferences)

**Key changes:**
- Updated backend logic to pass and process all input fields
- Enhanced prompt design for Azure OpenAI to include user preferences
- Structured output now reflects servings, restrictions, and extra inputs
- Added comprehensive tests (9 cases, all passing)

Closes #88 